### PR TITLE
Transition to pep compliant methods

### DIFF
--- a/openevsewifi/__init__.py
+++ b/openevsewifi/__init__.py
@@ -2,6 +2,7 @@ import re
 import requests
 import datetime
 
+from deprecated import deprecated
 from typing import (
   List,
   Optional
@@ -30,12 +31,12 @@ colors = ['off', 'red', 'green', 'yellow', 'blue', 'violet', 'teal', 'white']
 class Charger:
     def __init__(self, host: str):
         """A connection to an OpenEVSE charging station equipped with the wifi kit."""
-        self.url = 'http://' + host + '/r?'
+        self._url = 'http://' + host + '/r?'
 
-    def sendCommand(self, command: str) -> List[str]:
+    def _send_command(self, command: str) -> List[str]:
         """Sends a command through the web interface of the charger and parses the response"""
         data = {'rapi': command}
-        content = requests.post(self.url, data=data)
+        content = requests.post(self._url, data=data)
         response = re.search('\\<p>&gt;\\$([^\\^]+)(\\^..)?<script', content.text)
         # If we are using version 1
         # https://github.com/OpenEVSE/ESP8266_WiFi_v1.x/blob/master/OpenEVSE_RAPI_WiFi_ESP8266.ino#L357
@@ -43,117 +44,202 @@ class Charger:
             response = re.search('\\>\\>\\$(.+)\\<p>', content.text)
         return response.group(1).split()
 
+    @deprecated(reason='Use the status property')
     def getStatus(self) -> str:
+        return self.status
+
+    @property
+    def status(self) -> str:
         """Returns the charger's charge status, as a string"""
         command = '$GS'
-        status = self.sendCommand(command)
+        status = self._send_command(command)
         return states[int(status[1])]
 
+    @deprecated(reason='Use the charge_time_elapsed property')
     def getChargeTimeElapsed(self) -> int:
+        return self.charge_time_elapsed
+
+    @property
+    def charge_time_elapsed(self) -> int:
         """Returns the charge time elapsed (in seconds), or 0 if is not currently charging"""
         command = '$GS'
-        status = self.sendCommand(command)
+        status = self._send_command(command)
         if int(status[1]) == 3:
             return int(status[2])
         else:
             return 0
 
+    @deprecated(reason='Use time_limit property')
     def getTimeLimit(self) -> int:
+        return self.time_limit
+
+    @property
+    def time_limit(self) -> int:
         """Returns the time limit in minutes or 0 if no limit is set"""
         command = '$G3'
-        limit = self.sendCommand(command)
+        limit = self._send_command(command)
         return int(limit[1])*15
 
+    @deprecated(reason='Use ammeter_scale_factor property')
     def getAmmeterScaleFactor(self) -> int:
+        return self.ammeter_scale_factor
+
+    @property
+    def ammeter_scale_factor(self) -> int:
         """Returns the ammeter's current scale factor"""
         command = '$GA'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         return int(settings[1])
 
+    @deprecated(reason='Use ammeter_offset property')
     def getAmmeterOffset(self) -> int:
+        return self.ammeter_offset
+
+    @property
+    def ammeter_offset(self) -> int:
         """Returns the ammeter's current offset"""
         command = '$GA'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         return int(settings[2])
 
+    @deprecated(reason='Use min_amps property')
     def getMinAmps(self) -> int:
+        return self.min_amps
+
+    @property
+    def min_amps(self) -> int:
         """Returns the capacity range minimum, in amps"""
         command = '$GC'
-        caprange = self.sendCommand(command)
+        caprange = self._send_command(command)
         return int(caprange[1])
 
+    @deprecated(reason='Use max_amps property')
     def getMaxAmps(self) -> int:
+        return self.max_amps
+
+    @property
+    def max_amps(self) -> int:
         """Returns the capacity range maximum, in amps"""
         command = '$GC'
-        caprange = self.sendCommand(command)
+        caprange = self._send_command(command)
         return int(caprange[2])
 
+    @deprecated(reason='Use current_capacity property')
     def getCurrentCapacity(self) -> int:
+        return self.current_capacity
+
+    @property
+    def current_capacity(self) -> int:
         """Returns the current capacity, in amps"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         return int(settings[1])
 
-    def getServiceLevel(self) -> int:
+    @deprecated(reason='Use service_level property')
+    def getServiceLevel(self) ->  int:
+        return self.service_level
+
+    @property
+    def service_level(self) -> int:
         """Returns the service level"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return (flags & 0x0001) + 1
 
+    @deprecated(reason='Use diode_check_enabled property')
     def getDiodeCheckEnabled(self) -> bool:
+        return self.diode_check_enabled
+
+    @property
+    def diode_check_enabled(self) -> bool:
         """Returns True if enabled, False if disabled"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return not (flags & 0x0002)
 
+    @deprecated(reason='Use vent_required_enabled property')
     def getVentRequiredEnabled(self) -> bool:
+        return self.vent_required_enabled
+
+    @property
+    def vent_required_enabled(self) -> bool:
         """Returns True if enabled, False if disabled"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return not (flags & 0x0004)
 
+    @deprecated(reason='Use ground_check_enabled property')
     def getGroundCheckEnabled(self) -> bool:
+        return self.ground_check_enabled
+
+    @property
+    def ground_check_enabled(self) -> bool:
         """Returns True if enabled, False if disabled"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return not (flags & 0x0008)
 
+    @deprecated(reason='Use stuck_relay_check_enabled property')
     def getStuckRelayCheckEnabled(self) -> bool:
+        return self.stuck_relay_check_enabled
+
+    @property
+    def stuck_relay_check_enabled(self) -> bool:
         """Returns True if enabled, False if disabled"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return not (flags & 0x0010)
 
+    @deprecated(reason='Use auto_service_level_enabled property')
     def getAutoServiceLevelEnabled(self) -> bool:
+        return self.auto_service_level_enabled
+
+    @property
+    def auto_service_level_enabled(self) -> bool:
         """Returns True if enabled, False if disabled"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return not (flags & 0x0020)
 
+    @deprecated(reason='Use auto_start_enabled property')
     def getAutoStartEnabled(self) -> bool:
+        return self.auto_start_enabled
+
+    @property
+    def auto_start_enabled(self) -> bool:
         """Returns True if enabled, False if disabled"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return not (flags & 0x0040)
 
+    @deprecated(reason='Use serial_debug_enabled property')
     def getSerialDebugEnabled(self) -> bool:
+        return self.serial_debug_enabled
+
+    @property
+    def serial_debug_enabled(self) -> bool:
         """Returns True if enabled, False if disabled"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return not (flags & 0x0080)
 
+    @deprecated(reason='Use lcd_type property')
     def getLCDType(self) -> str:
+        return self.lcd_type
+
+    @property
+    def lcd_type(self) -> str:
         """Returns LCD type as a string, either monochrome or rgb"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         if flags & 0x0100:
             lcdtype = 'monochrome'
@@ -161,112 +247,187 @@ class Charger:
             lcdtype = 'rgb'
         return lcdtype
 
+    @deprecated(reason='Use gfi_self_test_enabled property')
     def getGFISelfTestEnabled(self) -> bool:
+        return self.gfi_self_test_enabled
+
+    @property
+    def gfi_self_test_enabled(self) -> bool:
         """Returns True if enabled, False if disabled"""
         command = '$GE'
-        settings = self.sendCommand(command)
+        settings = self._send_command(command)
         flags = int(settings[2], 16)
         return not (flags & 0x0200)
 
+    @deprecated(reason='Use gfi_trip_count property')
     def getGFITripCount(self) -> int:
+        return self.gfi_trip_count
+
+    @property
+    def gfi_trip_count(self) -> int:
         """Returns GFI Trip Count, as integer"""
         command = '$GF'
-        faults = self.sendCommand(command)
+        faults = self._send_command(command)
         return int(faults[1])
 
+    @deprecated(reason='Use no_gnd_trip_count property')
     def getNoGndTripCount(self) -> int:
+        return self.no_gnd_trip_count
+
+    @property
+    def no_gnd_trip_count(self) -> int:
         """Returns No Ground Trip Count, as integer"""
         command = '$GF'
-        faults = self.sendCommand(command)
+        faults = self._send_command(command)
         return int(faults[2])
 
+    @deprecated(reason='Use stuck_relay_trip_count property')
     def getStuckRelayTripCount(self) -> int:
+        return self.stuck_relay_trip_count
+
+    @property
+    def stuck_relay_trip_count(self) -> int:
         """Returns Stuck Relay Trip Count, as integer"""
         command = '$GF'
-        faults = self.sendCommand(command)
+        faults = self._send_command(command)
         return int(faults[3])
 
+    @deprecated(reason='Use charging_current property')
     def getChargingCurrent(self) -> float:
+        return self.charging_current
+
+    @property
+    def charging_current(self) -> float:
         """Returns the charging current, in amps, or 0.0 of not charging"""
         command = '$GG'
-        current_and_voltage = self.sendCommand(command)
+        current_and_voltage = self._send_command(command)
         amps = float(current_and_voltage[1])/1000
         return amps if amps > 0 else 0.0
 
+    @deprecated(reason='Use charging_voltage property')
     def getChargingVoltage(self) -> float:
+        return self.charging_voltage
+
+    @property
+    def charging_voltage(self) -> float:
         """Returns the charging voltage, in volts, or 0.0 of not charging"""
         command = '$GG'
-        current_and_voltage = self.sendCommand(command)
+        current_and_voltage = self._send_command(command)
         volts = float(current_and_voltage[2])/1000
         return volts if volts > 0 else 0.0
 
+    @deprecated(reason='Use charge_limit property')
     def getChargeLimit(self) -> int:
+        return self.charge_limit
+
+    @property
+    def charge_limit(self) -> int:
         """Returns the charge limit in kWh"""
         command = '$GH'
-        limit = self.sendCommand(command)
+        limit = self._send_command(command)
         return int(limit[1])
 
+    @deprecated(reason='Use volt_meter_scale_factor property')
     def getVoltMeterScaleFactor(self) -> int:
+        return self.volt_meter_scale_factor
+
+    @property
+    def volt_meter_scale_factor(self) -> int:
         """Returns the voltmeter scale factor, or 0 if there is no voltmeter"""
         command = '$GM'
-        volt_meter_settings = self.sendCommand(command)
+        volt_meter_settings = self._send_command(command)
         if volt_meter_settings[0] == 'NK':
             return 0
         else:
             return int(volt_meter_settings[1])
 
+    @deprecated(reason='Use volt_meter_offset property')
     def getVoltMeterOffset(self) -> int:
+        return self.volt_meter_offset
+
+    @property
+    def volt_meter_offset(self) -> int:
         """Returns the voltmeter offset, or 0 if there is no voltmeter"""
         command = '$GM'
-        volt_meter_settings = self.sendCommand(command)
+        volt_meter_settings = self._send_command(command)
         if volt_meter_settings[0] == 'NK':
             return 0
         else:
             return int(volt_meter_settings[2])
 
+    @deprecated(reason='Use ambient_threshold property')
     def getAmbientThreshold(self) -> float:
+        return self.ambient_threshold
+
+    @property
+    def ambient_threshold(self) -> float:
         """Returns the ambient temperature threshold in degrees Celcius, or 0 if no Threshold is set"""
         command = '$GO'
-        threshold = self.sendCommand(command)
+        threshold = self._send_command(command)
         if threshold[0] == 'NK':
             return 0.0
         else:
             return float(threshold[1])/10
 
+    @deprecated(reason='Use ir_threshold property')
     def getIRThreshold(self) -> float:
+        return self.ir_threshold
+
+    @property
+    def ir_threshold(self) -> float:
         """Returns the IR temperature threshold in degrees Celcius, or 0 if no Threshold is set"""
         command = '$GO'
-        threshold = self.sendCommand(command)
+        threshold = self._send_command(command)
         if threshold[0] == 'NK':
             return 0.0
         else:
             return float(threshold[2])/10
 
+    @deprecated(reason='Use rtc_temperature property')
     def getRTCTemperature(self) -> float:
+        return self.rtc_temperature
+
+    @property
+    def rtc_temperature(self) -> float:
         """Returns the temperature of the real time clock sensor (DS3231), in degrees Celcius, or 0.0 if sensor is not
         installed"""
         command = '$GP'
-        temperature = self.sendCommand(command)
+        temperature = self._send_command(command)
         return float(temperature[1])/10
 
+    @deprecated(reason='Use ambient_temperature property')
     def getAmbientTemperature(self) -> float:
+        return self.ambient_temperature
+
+    @property
+    def ambient_temperature(self) -> float:
         """Returns the temperature of the ambient sensor (MCP9808), in degrees Celcius, or 0.0 if sensor is not
         installed"""
         command = '$GP'
-        temperature = self.sendCommand(command)
+        temperature = self._send_command(command)
         return float(temperature[2])/10
 
+    @deprecated(reason='Use ir_temperature property')
     def getIRTemperature(self) -> float:
+        return self.ir_temperature
+
+    @property
+    def ir_temperature(self) -> float:
         """Returns the temperature of the IR remote sensor (TMP007), in degrees Celcius, or 0.0 if sensor is not
         installed"""
         command = '$GP'
-        temperature = self.sendCommand(command)
+        temperature = self._send_command(command)
         return float(temperature[3])/10
 
+    @deprecated(reason='Use the time property')
     def getTime(self) -> Optional[datetime.datetime]:
+        return self.time
+
+    @property
+    def time(self) -> Optional[datetime.datetime]:
         """Get the RTC time.  Returns a datetime object, or NULL if the clock is not set"""
         command = '$GT'
-        time = self.sendCommand(command)
+        time = self._send_command(command)
         if time == ['OK', '165', '165', '165', '165', '165', '85']:
             return None
         else:
@@ -277,26 +438,46 @@ class Charger:
                                      minute=int(time[5]),
                                      second=int(time[6]))
 
+    @deprecated(reason='Use usage_session property')
     def getUsageSession(self) -> float:
+        return self.usage_session
+
+    @property
+    def usage_session(self) -> float:
         """Get the energy usage for the current charging session.  Returns the energy usage in Wh"""
         command = '$GU'
-        usage = self.sendCommand(command)
+        usage = self._send_command(command)
         return float(usage[1])/3600
 
+    @deprecated(reason='Use usage_total property')
     def getUsageTotal(self) -> float:
+        return self.usage_total
+
+    @property
+    def usage_total(self) -> float:
         """Get the total energy usage.  Returns the energy usage in Wh"""
         command = '$GU'
-        usage = self.sendCommand(command)
+        usage = self._send_command(command)
         return float(usage[2])
 
+    @deprecated(reason='Use firmware_version property')
     def getFirmwareVersion(self) -> str:
+        return self.firmware_version
+
+    @property
+    def firmware_version(self) -> str:
         """Returns the Firmware Version, as a string"""
         command = '$GV'
-        version = self.sendCommand(command)
+        version = self._send_command(command)
         return version[1]
 
+    @deprecated(reason='Use protocol_version property')
     def getProtocolVersion(self) -> str:
+        return self.protocol_version
+
+    @property
+    def protocol_version(self) -> str:
         """Returns the Protocol Version, as a string"""
         command = '$GV'
-        version = self.sendCommand(command)
+        version = self._send_command(command)
         return version[2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/miniconfig/python-openevse-wifi"
 python = "^3.5"
 requests = "^2.23.0"
 pytest-cov = "^2.8.1"
+Deprecated = "^1.2.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.1"

--- a/tests/test_charger_interface.py
+++ b/tests/test_charger_interface.py
@@ -6,144 +6,311 @@ from tests.utils import load_fixture
 @pytest.mark.parametrize('fixture, expected',
                          [('v1_responses/status_unplugged.txt', 'not connected'),
                           ('v1_responses/status_charging.txt', 'charging')])
+def test_get_status_deprecated(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    with pytest.deprecated_call():
+        status = test_charger.getStatus()
+    assert status == expected
+
+
+@pytest.mark.parametrize('fixture, expected',
+                         [('v1_responses/status_unplugged.txt', 'not connected'),
+                          ('v1_responses/status_charging.txt', 'charging')])
 def test_get_status(test_charger, requests_mock, fixture, expected):
-    requests_mock.post(test_charger.url, text=load_fixture(fixture))
-    status = test_charger.getStatus()
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    status = test_charger.status
     assert status == expected
 
 
 @pytest.mark.parametrize('fixture, expected',
                          [('v1_responses/status_unplugged.txt', 0),
                           ('v1_responses/status_charging.txt', 568)])
+def test_get_charge_time_elapsed_deprecated(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    with pytest.deprecated_call():
+        charge_time = test_charger.getChargeTimeElapsed()
+    assert charge_time == expected
+
+
+@pytest.mark.parametrize('fixture, expected',
+                         [('v1_responses/status_unplugged.txt', 0),
+                          ('v1_responses/status_charging.txt', 568)])
 def test_get_charge_time_elapsed(test_charger, requests_mock, fixture, expected):
-    requests_mock.post(test_charger.url, text=load_fixture(fixture))
-    charge_time = test_charger.getChargeTimeElapsed()
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    charge_time = test_charger.charge_time_elapsed
     assert charge_time == expected
 
 
 @pytest.mark.parametrize('fixture, expected',
                          [('v1_responses/time_limit_unset.txt', 0),
                           ('v1_responses/time_limit_set.txt', 630)])
-def test_get_time_limit(test_charger, requests_mock, fixture, expected):
-    requests_mock.post(test_charger.url, text=load_fixture(fixture))
-    time_limit = test_charger.getTimeLimit()
+def test_get_time_limit_deprecated(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    with pytest.deprecated_call():
+        time_limit = test_charger.getTimeLimit()
     assert time_limit == expected
 
 
-def test_get_ammeter_scale_factor(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/ammeter.txt'))
-    scale_factor = test_charger.getAmmeterScaleFactor()
+@pytest.mark.parametrize('fixture, expected',
+                         [('v1_responses/time_limit_unset.txt', 0),
+                          ('v1_responses/time_limit_set.txt', 630)])
+def test_get_time_limit(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    time_limit = test_charger.time_limit
+    assert time_limit == expected
+
+
+def test_get_ammeter_scale_factor_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/ammeter.txt'))
+    with pytest.deprecated_call():
+        scale_factor = test_charger.getAmmeterScaleFactor()
     assert scale_factor == 220
 
 
-def test_get_ammeter_offsset(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/ammeter.txt'))
-    offset = test_charger.getAmmeterOffset()
+def test_get_ammeter_scale_factor(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/ammeter.txt'))
+    scale_factor = test_charger.ammeter_scale_factor
+    assert scale_factor == 220
+
+
+def test_get_ammeter_offset_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/ammeter.txt'))
+    with pytest.deprecated_call():
+        offset = test_charger.getAmmeterOffset()
     assert offset == 0
 
 
-def test_get_min_amps(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/capacity_range.txt'))
-    amps = test_charger.getMinAmps()
+def test_get_ammeter_offset(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/ammeter.txt'))
+    offset = test_charger.ammeter_offset
+    assert offset == 0
+
+
+def test_get_min_amps_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/capacity_range.txt'))
+    with pytest.deprecated_call():
+        amps = test_charger.getMinAmps()
     assert amps == 6
 
 
-def test_get_max_amps(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/capacity_range.txt'))
-    amps = test_charger.getMaxAmps()
+def test_get_min_amps(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/capacity_range.txt'))
+    amps = test_charger.min_amps
+    assert amps == 6
+
+
+def test_get_max_amps_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/capacity_range.txt'))
+    with pytest.deprecated_call():
+        amps = test_charger.getMaxAmps()
     assert amps == 80
 
 
-def test_get_current_capacity(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    amps = test_charger.getCurrentCapacity()
+def test_get_max_amps(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/capacity_range.txt'))
+    amps = test_charger.max_amps
+    assert amps == 80
+
+
+def test_get_current_capacity_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        amps = test_charger.getCurrentCapacity()
     assert amps == 50
 
 
-def test_get_service_level(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    level = test_charger.getServiceLevel()
+def test_get_current_capacity(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    amps = test_charger.current_capacity
+    assert amps == 50
+
+
+def test_get_service_level_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        level = test_charger.getServiceLevel()
     assert level == 2
 
 
+def test_get_service_level(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    level = test_charger.service_level
+    assert level == 2
+
+
+def test_get_diode_check_enabled_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        enabled = test_charger.getDiodeCheckEnabled()
+    assert enabled is True
+
+
 def test_get_diode_check_enabled(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    enabled = test_charger.getDiodeCheckEnabled()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    enabled = test_charger.diode_check_enabled
+    assert enabled is True
+
+
+def test_get_vent_required_enabled_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        enabled = test_charger.getVentRequiredEnabled()
     assert enabled is True
 
 
 def test_get_vent_required_enabled(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    enabled = test_charger.getVentRequiredEnabled()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    enabled = test_charger.vent_required_enabled
+    assert enabled is True
+
+
+def test_get_ground_check_enabled_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        enabled = test_charger.getGroundCheckEnabled()
     assert enabled is True
 
 
 def test_get_ground_check_enabled(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    enabled = test_charger.getGroundCheckEnabled()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    enabled = test_charger.ground_check_enabled
+    assert enabled is True
+
+
+def test_get_stuck_relay_check_enabled_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        enabled = test_charger.getStuckRelayCheckEnabled()
     assert enabled is True
 
 
 def test_get_stuck_relay_check_enabled(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    enabled = test_charger.getGroundCheckEnabled()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    enabled = test_charger.stuck_relay_check_enabled
     assert enabled is True
 
 
-def test_get_auto_service_level_enabled(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    enabled = test_charger.getAutoServiceLevelEnabled()
+def test_get_auto_service_level_enabled_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        enabled = test_charger.getAutoServiceLevelEnabled()
     assert enabled is False
 
 
+def test_get_auto_service_level_enabled(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    enabled = test_charger.auto_service_level_enabled
+    assert enabled is False
+
+
+def test_get_auto_start_enabled_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        enabled = test_charger.getAutoStartEnabled()
+    assert enabled is True
+
+
 def test_get_auto_start_enabled(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    enabled = test_charger.getAutoStartEnabled()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    enabled = test_charger.auto_start_enabled
+    assert enabled is True
+
+
+def test_get_serial_debug_enabled_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        enabled = test_charger.getSerialDebugEnabled()
     assert enabled is True
 
 
 def test_get_serial_debug_enabled(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    enabled = test_charger.getDiodeCheckEnabled()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    enabled = test_charger.serial_debug_enabled
     assert enabled is True
 
 
-def test_get_lcd_type(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    lcd_type = test_charger.getLCDType()
+def test_get_lcd_type_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        lcd_type = test_charger.getLCDType()
     assert lcd_type == 'rgb'
 
 
-def test_get_gfi_self_test_enabled(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/settings.txt'))
-    enabled = test_charger.getGFISelfTestEnabled()
+def test_get_lcd_type(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    lcd_type = test_charger.lcd_type
+    assert lcd_type == 'rgb'
+
+
+def test_get_gfi_self_test_enabled_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    with pytest.deprecated_call():
+        enabled = test_charger.getGFISelfTestEnabled()
     assert enabled is False
 
 
-def test_get_gfi_trip_count(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/faults.txt'))
-    count = test_charger.getGFITripCount()
+def test_get_gfi_self_test_enabled(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/settings.txt'))
+    enabled = test_charger.gfi_self_test_enabled
+    assert enabled is False
+
+
+def test_get_gfi_trip_count_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/faults.txt'))
+    with pytest.deprecated_call():
+        count = test_charger.getGFITripCount()
     assert count == 0
 
 
-def test_get_no_ground_trip_count(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/faults.txt'))
-    count = test_charger.getNoGndTripCount()
+def test_get_gfi_trip_count(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/faults.txt'))
+    count = test_charger.gfi_trip_count
+    assert count == 0
+
+
+def test_get_no_ground_trip_count_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/faults.txt'))
+    with pytest.deprecated_call():
+        count = test_charger.getNoGndTripCount()
     assert count == 9
 
 
+def test_get_no_ground_trip_count(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/faults.txt'))
+    count = test_charger.no_gnd_trip_count
+    assert count == 9
+
+
+def test_get_stuck_relay_trip_count_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/faults.txt'))
+    with pytest.deprecated_call():
+        count = test_charger.getStuckRelayTripCount()
+    assert count == 0
+
+
 def test_get_stuck_relay_trip_count(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/faults.txt'))
-    count = test_charger.getStuckRelayTripCount()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/faults.txt'))
+    count = test_charger.stuck_relay_trip_count
     assert count == 0
 
 
 @pytest.mark.parametrize('fixture, expected',
                          [('v1_responses/charging_values_unplugged.txt', 0.0),
                           ('v1_responses/charging_values_charging.txt', 10.34)])
+def test_get_charging_current_deprecated(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    with pytest.deprecated_call():
+        current = test_charger.getChargingCurrent()
+    assert current == expected
+    assert type(current) == float
+
+
+@pytest.mark.parametrize('fixture, expected',
+                         [('v1_responses/charging_values_unplugged.txt', 0.0),
+                          ('v1_responses/charging_values_charging.txt', 10.34)])
 def test_get_charging_current(test_charger, requests_mock, fixture, expected):
-    requests_mock.post(test_charger.url, text=load_fixture(fixture))
-    current = test_charger.getChargingCurrent()
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    current = test_charger.charging_current
     assert current == expected
     assert type(current) == float
 
@@ -151,78 +318,179 @@ def test_get_charging_current(test_charger, requests_mock, fixture, expected):
 @pytest.mark.parametrize('fixture, expected',
                          [('v1_responses/charging_values_unplugged.txt', 0.0),
                           ('v1_responses/charging_values_charging.txt', 0.0)])
-def test_get_charging_voltage(test_charger, requests_mock, fixture, expected):
-    requests_mock.post(test_charger.url, text=load_fixture(fixture))
-    voltage = test_charger.getChargingVoltage()
+def test_get_charging_voltage_deprecated(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    with pytest.deprecated_call():
+        voltage = test_charger.getChargingVoltage()
     assert voltage == expected
     assert type(voltage) == float
 
 
-def test_get_charge_limit(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/charge_limit.txt'))
-    limit = test_charger.getChargeLimit()
+@pytest.mark.parametrize('fixture, expected',
+                         [('v1_responses/charging_values_unplugged.txt', 0.0),
+                          ('v1_responses/charging_values_charging.txt', 0.0)])
+def test_get_charging_voltage(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    voltage = test_charger.charging_voltage
+    assert voltage == expected
+    assert type(voltage) == float
+
+
+def test_get_charge_limit_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/charge_limit.txt'))
+    with pytest.deprecated_call():
+        limit = test_charger.getChargeLimit()
     assert limit == 0
 
 
-def test_get_voltmeter_scale_factor(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/voltmeter_settings.txt'))
-    scale = test_charger.getVoltMeterScaleFactor()
+def test_get_charge_limit(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/charge_limit.txt'))
+    limit = test_charger.charge_limit
+    assert limit == 0
+
+
+def test_get_voltmeter_scale_factor_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/voltmeter_settings.txt'))
+    with pytest.deprecated_call():
+        scale = test_charger.getVoltMeterScaleFactor()
     assert scale == 0
 
 
-def test_get_voltmeter_offset(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/voltmeter_settings.txt'))
-    offset = test_charger.getVoltMeterOffset()
+def test_get_voltmeter_scale_factor(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/voltmeter_settings.txt'))
+    scale = test_charger.volt_meter_scale_factor
+    assert scale == 0
+
+
+def test_get_voltmeter_offset_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/voltmeter_settings.txt'))
+    with pytest.deprecated_call():
+        offset = test_charger.getVoltMeterOffset()
     assert offset == 0
 
 
+def test_get_voltmeter_offset(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/voltmeter_settings.txt'))
+    offset = test_charger.volt_meter_offset
+    assert offset == 0
+
+
+def test_get_ambient_threshold_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_settings.txt'))
+    with pytest.deprecated_call():
+        threshold = test_charger.getAmbientThreshold()
+    assert threshold == 0.0
+    assert type(threshold) == float
+
+
 def test_get_ambient_threshold(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/temperature_settings.txt'))
-    threshold = test_charger.getAmbientThreshold()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_settings.txt'))
+    threshold = test_charger.ambient_threshold
+    assert threshold == 0.0
+    assert type(threshold) == float
+
+
+def test_get_ir_threshold_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_settings.txt'))
+    with pytest.deprecated_call():
+        threshold = test_charger.getIRThreshold()
     assert threshold == 0.0
     assert type(threshold) == float
 
 
 def test_get_ir_threshold(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/temperature_settings.txt'))
-    threshold = test_charger.getIRThreshold()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_settings.txt'))
+    threshold = test_charger.ir_threshold
     assert threshold == 0.0
     assert type(threshold) == float
 
 
-def test_get_rtc_temperature(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/temperature_values.txt'))
-    temperature = test_charger.getRTCTemperature()
+def test_get_rtc_temperature_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_values.txt'))
+    with pytest.deprecated_call():
+        temperature = test_charger.getRTCTemperature()
     assert temperature == 59.2
     assert type(temperature) == float
 
 
-def test_get_ambient_temperature(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/temperature_values.txt'))
-    temperature = test_charger.getAmbientTemperature()
+def test_get_rtc_temperature(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_values.txt'))
+    temperature = test_charger.rtc_temperature
+    assert temperature == 59.2
+    assert type(temperature) == float
+
+
+def test_get_ambient_temperature_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_values.txt'))
+    with pytest.deprecated_call():
+        temperature = test_charger.getAmbientTemperature()
     assert temperature == 0.0
     assert type(temperature) == float
 
 
-def test_get_ir_temperature(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/temperature_values.txt'))
-    temperature = test_charger.getIRTemperature()
+def test_get_ambient_temperature(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_values.txt'))
+    temperature = test_charger.ambient_temperature
+    assert temperature == 0.0
+    assert type(temperature) == float
+
+
+def test_get_ir_temperature_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_values.txt'))
+    with pytest.deprecated_call():
+        temperature = test_charger.getIRTemperature()
     assert temperature == 23.0
     assert type(temperature) == float
 
 
+def test_get_ir_temperature(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/temperature_values.txt'))
+    temperature = test_charger.ir_temperature
+    assert temperature == 23.0
+    assert type(temperature) == float
+
+
+def test_get_time_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/time.txt'))
+    with pytest.deprecated_call():
+        time = test_charger.getTime()
+    assert str(time) == '2000-01-20 08:34:29'
+
+
 def test_get_time(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/time.txt'))
-    time = test_charger.getTime()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/time.txt'))
+    time = test_charger.time
     assert str(time) == '2000-01-20 08:34:29'
 
 
 @pytest.mark.parametrize('fixture, expected',
                          [('v1_responses/usage_unplugged.txt', 0.0),
                           ('v1_responses/usage_charging.txt', 779.8663888888889)])
+def test_get_usage_session_deprecated(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    with pytest.deprecated_call():
+        usage = test_charger.getUsageSession()
+    assert usage == expected
+    assert type(usage) == float
+
+
+@pytest.mark.parametrize('fixture, expected',
+                         [('v1_responses/usage_unplugged.txt', 0.0),
+                          ('v1_responses/usage_charging.txt', 779.8663888888889)])
 def test_get_usage_session(test_charger, requests_mock, fixture, expected):
-    requests_mock.post(test_charger.url, text=load_fixture(fixture))
-    usage = test_charger.getUsageSession()
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    usage = test_charger.usage_session
+    assert usage == expected
+    assert type(usage) == float
+
+
+@pytest.mark.parametrize('fixture, expected',
+                         [('v1_responses/usage_unplugged.txt', 12419994.0),
+                          ('v1_responses/usage_charging.txt', 12419994.0)])
+def test_get_usage_total_deprecated(test_charger, requests_mock, fixture, expected):
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    with pytest.deprecated_call():
+        usage = test_charger.getUsageTotal()
     assert usage == expected
     assert type(usage) == float
 
@@ -231,21 +499,37 @@ def test_get_usage_session(test_charger, requests_mock, fixture, expected):
                          [('v1_responses/usage_unplugged.txt', 12419994.0),
                           ('v1_responses/usage_charging.txt', 12419994.0)])
 def test_get_usage_total(test_charger, requests_mock, fixture, expected):
-    requests_mock.post(test_charger.url, text=load_fixture(fixture))
-    usage = test_charger.getUsageTotal()
+    requests_mock.post(test_charger._url, text=load_fixture(fixture))
+    usage = test_charger.usage_total
     assert usage == expected
     assert type(usage) == float
 
 
-def test_get_firmware_version(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/version.txt'))
-    version = test_charger.getFirmwareVersion()
+def test_get_firmware_version_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/version.txt'))
+    with pytest.deprecated_call():
+        version = test_charger.getFirmwareVersion()
     assert version == '3.11.3'
     assert type(version) == str
 
 
+def test_get_firmware_version(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/version.txt'))
+    version = test_charger.firmware_version
+    assert version == '3.11.3'
+    assert type(version) == str
+
+
+def test_get_protocol_version_deprecated(test_charger, requests_mock):
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/version.txt'))
+    with pytest.deprecated_call():
+        version = test_charger.getProtocolVersion()
+    assert version == '1.0.3'
+    assert type(version) == str
+
+
 def test_get_protocol_version(test_charger, requests_mock):
-    requests_mock.post(test_charger.url, text=load_fixture('v1_responses/version.txt'))
-    version = test_charger.getProtocolVersion()
+    requests_mock.post(test_charger._url, text=load_fixture('v1_responses/version.txt'))
+    version = test_charger.protocol_version
     assert version == '1.0.3'
     assert type(version) == str


### PR DESCRIPTION
Before adding write access, I want to get rid of the non-pep-compliant camel case methods and introduce a more pythonic API.  Most of the changes here are backwards compatible, as utilizing the older methods will only throw a deprecation warning.  There are, however, two *breaking changes*:
* the url property is now a private property
* the SendCommand method has now been replaced with the private _send_command