### PR TITLE
🚑 Move pytest-cov to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ repository = "https://github.com/miniconfig/python-openevse-wifi"
 [tool.poetry.dependencies]
 python = "^3.5"
 requests = "^2.23.0"
-pytest-cov = "^2.8.1"
 Deprecated = "^1.2.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.1"
+pytest-cov = "^2.8.1"
 requests-mock = "^1.7.0"
 flake8 = "^3.7.9"
 


### PR DESCRIPTION
Moves the `pytest-cov` dependency to the list of dev dependencies.

Currently, this block Home Assistant from upgrading the `pytest-cov`.

A merge and release would be appreciated, as it helps us unblocking upgrades.

Thanks!

../Frenck

Upstream: <https://github.com/home-assistant/core/pull/68611>